### PR TITLE
added OS Generated files section to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,13 @@ docs/_build/
 
 local_settings.py
 *.swp
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+~*


### PR DESCRIPTION
I added a few lines, most importantly to ignore the pesky ".DS_Store" file, which is the mac osx generated thumbnails.
