### PR TITLE
Fix import bug with large amounts of data

### DIFF
--- a/institutions/geo/migrations/0004_minmax_latlon.py
+++ b/institutions/geo/migrations/0004_minmax_latlon.py
@@ -9,7 +9,7 @@ class Migration(DataMigration):
         # Note: Don't use "from appname.models import ModelName".
         # Use orm.ModelName to refer to models in this application,
         # and orm['appname.ModelName'] for models in other applications.
-        for tract in orm.StateCensusTract.objects.all():
+        for tract in orm.StateCensusTract.objects.iterator():
             # Can't use auto_fields since we are using south's ORM
             lons, lats = zip(*[pt for polygon in tract.geom.coords
                                for line in polygon

--- a/institutions/geo/migrations/0007_precompute_geojson.py
+++ b/institutions/geo/migrations/0007_precompute_geojson.py
@@ -11,7 +11,7 @@ class Migration(DataMigration):
         # Note: Don't use "from appname.models import ModelName".
         # Use orm.ModelName to refer to models in this application,
         # and orm['appname.ModelName'] for models in other applications.
-        for geo in orm.StateCensusTract.objects.all():
+        for geo in orm.StateCensusTract.objects.iterator():
             geojson = {"type": "Feature", "geometry": "$_$"}
             geojson['properties'] = {
                 'statefp': geo.statefp,

--- a/institutions/geo/migrations/0009_refresh_geojson.py
+++ b/institutions/geo/migrations/0009_refresh_geojson.py
@@ -8,7 +8,7 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         "Write your forwards methods here."
-        for geo in orm.StateCensusTract.objects.all():
+        for geo in orm.StateCensusTract.objects.iterator():
             geojson = {"type": "Feature", "geometry": "$_$"}
             geojson['properties'] = {
                 'statefp': geo.statefp,
@@ -35,7 +35,7 @@ class Migration(DataMigration):
 
     def backwards(self, orm):
         "Write your backwards methods here."
-        for geo in orm.StateCensusTract.objects.all():
+        for geo in orm.StateCensusTract.objects.iterator():
             geojson = {"type": "Feature", "geometry": "$_$"}
             geojson['properties'] = {
                 'statefp': geo.statefp,

--- a/institutions/geo/migrations/0014_tract_to_geo.py
+++ b/institutions/geo/migrations/0014_tract_to_geo.py
@@ -12,7 +12,7 @@ class Migration(DataMigration):
         # Use orm.ModelName to refer to models in this application,
         # and orm['appname.ModelName'] for models in other applications.
         batch = []
-        for tract in orm.StateCensusTract.objects.all():
+        for tract in orm.StateCensusTract.objects.iterator():
             # Don't use any constants as this is migration code
             geo = orm.Geo(geoid=tract.geoid, geo_type=3, name=tract.name,
                           state=tract.statefp, county=tract.countyfp,


### PR DESCRIPTION
Django's orm caches query results by default, which is handy until you need to step through each of a few thousand complicated geometries (as when converting all US census tracts).

This replaces such queries with a call to `iterator()` a la https://docs.djangoproject.com/en/dev/ref/models/querysets/#iterator
