### PR TITLE
Make county boundaries opaque

### DIFF
--- a/institutions/mapping/static/mapping/js/map.js
+++ b/institutions/mapping/static/mapping/js/map.js
@@ -41,7 +41,7 @@ var Mapusaurus = {
     //  population-less tracts
     noStyle: {stroke: false, fill: false},
     //  used when census tracts are visible
-    zoomedCountyStyle: {stroke: true, color: '#fff', weight: 4, fill: false,
+    zoomedCountyStyle: {stroke: true, color: '#fff', weight: 2, fill: false,
                         opacity: 1.0},
     //  used when census tracts are not visible
     biggerCountyStyle: {stroke: true, color: '#333', weight: 4, fill: false,


### PR DESCRIPTION
@ohsk: Merge this if you think it's the right direction.

Transparency county boundaries:
![screen shot 2014-07-24 at 3 03 33 am](https://cloud.githubusercontent.com/assets/326918/3684809/68cbccb4-1301-11e4-8091-43c1a6823d7b.png)

Opaque:
![screen shot 2014-07-24 at 3 04 39 am](https://cloud.githubusercontent.com/assets/326918/3684814/7011de6e-1301-11e4-83cb-bba9efb5d86e.png)

I think the latter's a step up.
