### PR TITLE
Use SVG for choropleth key instead of CSS

### DIFF
--- a/institutions/mapping/static/mapping/css/choropleth-key.svg
+++ b/institutions/mapping/static/mapping/css/choropleth-key.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<linearGradient id="choropleth-key" x1="0%" y1="0%" x2="100%" y2="0%">
+<stop stop-color="#FFFFD9" offset="0"/>
+<stop stop-color="#C6EAB2" offset="0.5"/>
+<stop stop-color="#0E90C2" offset="0.8"/>
+<stop stop-color="#1D5CAA" offset="1"/>
+</linearGradient>
+<rect x="0" y="0" width="100%" height="100%" fill="url(#choropleth-key)" />
+</svg>

--- a/institutions/mapping/static/mapping/css/map.css
+++ b/institutions/mapping/static/mapping/css/map.css
@@ -34,7 +34,8 @@
 #minority-key {
   width: 100%;
   margin-top: 5px;
-  background: linear-gradient(to right, #ffffd9, #c6eab2 50%, #0e90c2 80%, #1d5caa);
+  background-image: url(choropleth-key.svg);
+  /*background: linear-gradient(to right, #ffffd9, #c6eab2 50%, #0e90c2 80%, #1d5caa);*/
 }
 
 #key select {


### PR DESCRIPTION
This (should) make the key appear in IE9+ (as well as modern browsers)
