### PR TITLE
Set a min and max zoom level for the map

### DIFF
--- a/institutions/institutions/settings/settings.py
+++ b/institutions/institutions/settings/settings.py
@@ -99,6 +99,8 @@ LEAFLET_CONFIG = {
     'RESET_VIEW': False,
     'TILES': 'http://tile.stamen.com/toner-lite/{z}/{x}/{y}.jpg',
     'SCALE': 'imperial',
+    'MIN_ZOOM': 9,
+    'MAX_ZOOM': 15
 }
 
 HAYSTACK_CONNECTIONS = {


### PR DESCRIPTION
The min zoom of 9 matches when census tracts stop rendering and the max zoom of 15 is around the time when only a single census tract in downtown chicago is visible.
