### PR TITLE
Few-liner search speed boost

### DIFF
--- a/institutions/respondants/search_indexes.py
+++ b/institutions/respondants/search_indexes.py
@@ -27,5 +27,10 @@ class InstitutionIndex(indexes.SearchIndex, indexes.Indexable):
             select={"num_loans": "SELECT COUNT(*) " + subquery_tail},
             where=["SELECT COUNT(*) > 0 " + subquery_tail])
 
+    def read_queryset(self, using=None):
+        """A more efficient query than the index query -- makes use of select
+        related and does not include the num_loans calculation."""
+        return self.get_model().objects.select_related('zip_code', 'agency')
+
     def prepare_lender_id(self, institution):
         return str(institution.agency_id) + institution.ffiec_id


### PR DESCRIPTION
When fetching search results (not indexing), do not include the subselect (it's already in the index) and pre-fetch related fields. The latter avoids N+1 queries, in which we were making an additional query (two, actually) for each result.
