### PR TITLE
Reducing opacity of census tract choropleth layer

### DIFF
--- a/institutions/mapping/static/mapping/js/map.js
+++ b/institutions/mapping/static/mapping/js/map.js
@@ -59,7 +59,7 @@ var Mapusaurus = {
     //  Some style info
     bubbleStyle: {stroke: false, fillOpacity: 0.9, weight: 2},
     //  fillColor and color will be assigned when rendering
-    tractStyle: {stroke: false, fillOpacity: 0.4, weight: 2, fill: true,
+    tractStyle: {stroke: false, fillOpacity: 0.25, weight: 2, fill: true,
                  smoothFactor: 0.1},
     //  used when loading census tracts
     loadingStyle: {stroke: true, weight: 2, color: '#babbbd', fill: false,


### PR DESCRIPTION
Don't hate me, @cmc333333. I thought I was in Dreamweaver.

(But seriously, if doing this is overstepping my bounds, distracting, or not useful, just slap my hand and let me know!)
#### To resolve [FLM-211](https://jira.demo.cfpb.gov/browse/FLM-211)

Helps punch-up the visibility of the scaled circles, particularly for the middle-range tones on the color ramp. Tract layer should have just enough visibility of the overall minority distribution.

![flm-211_tract-opacity_02](https://cloud.githubusercontent.com/assets/1689222/3984671/fcdc32c0-2889-11e4-9ff6-f591ba4091ec.gif)
