### PR TITLE
Travis fix

### DIFF
--- a/institutions/geo/tests.py
+++ b/institutions/geo/tests.py
@@ -101,8 +101,13 @@ class ViewTest(TestCase):
 
         self.assertTrue(len(topo_str) < len(geo_str))
         topo_geo_dict = geojson(topo_dict)
-        print geo_dict
-        print topo_geo_dict
+        self.assertEqual(len(geo_dict['features']),
+                         len(topo_geo_dict['features']))
+        geo_dict['features'] = sorted(geo_dict['features'],
+                                      key=lambda f: f['properties']['geoid'])
+        topo_geo_dict['features'] = sorted(
+            topo_geo_dict['features'], key=lambda f: f['properties']['geoid'])
+        self.assertEqual(len(geo_dict['features']),  3)
         self.assertEqual(geo_dict, topo_geo_dict)
 
     @patch('geo.views.SearchQuerySet')


### PR DESCRIPTION
Travis would sometimes throw an error because the order of two lists might not match. Sort the lists so that this doesn't happen.
