### PR TITLE
Don't use django's test client when precaching

### DIFF
--- a/institutions/geo/tests.py
+++ b/institutions/geo/tests.py
@@ -143,17 +143,19 @@ class PrecacheTest(TestCase):
     def tearDown(self):
         Precache.urls = self.original_urls
 
-    @patch('geo.management.commands.precache_geos.Client')
+    @patch('geo.management.commands.precache_geos.urllib')
     def test_handle_with_args(self, client):
         Precache.urls['geo:topotiles'] = range(3, 6)
-        Precache().handle('3', '5')
-        self.assertEqual(7, client.return_value.get.call_count)
+        Precache().handle('http://example.com', '3', '5')
+        self.assertEqual(7, client.urlopen.call_count)
+        self.assertTrue('http://example.com' in client.urlopen.call_args[0][0])
 
-    @patch('geo.management.commands.precache_geos.Client')
+    @patch('geo.management.commands.precache_geos.urllib')
     def test_handle_no_args(self, client):
         Precache.urls['geo:topotiles'] = range(3, 6)
         Precache().handle()
-        self.assertEqual(22, client.return_value.get.call_count)
+        self.assertEqual(22, client.urlopen.call_count)
+        self.assertTrue('http://localhost' in client.urlopen.call_args[0][0])
 
 
 class SetTractCBSATest(TestCase):


### PR DESCRIPTION
The cache entries generated when using django's test client don't appear to be used when a real browser hits the app.
