### PR TITLE
Fix typo on Institution Search page

### DIFF
--- a/institutions/respondants/templates/respondants/search_home.html
+++ b/institutions/respondants/templates/respondants/search_home.html
@@ -28,7 +28,7 @@
                    <div class="circlelabel">1</div>
                 </div>
                 <div class="search-title-column2">
-                    <h3>  Find an institution with 2012 orginations</h3>
+                    <h3>  Find an institution with 2012 originations</h3>
                 </div>
             </div>
             <p>&nbsp;</p>


### PR DESCRIPTION
As noted by Orlando!
![c475c9ae-5882-11e4-8918-fa5c922e6977](https://cloud.githubusercontent.com/assets/1689222/4710124/d87a72f6-58a5-11e4-9aef-3b71db5280c6.png)
