### PR TITLE
Removed sequential / plurality options from layer menu

### DIFF
--- a/mapusaurus/mapping/templates/map.html
+++ b/mapusaurus/mapping/templates/map.html
@@ -114,10 +114,7 @@
             'Water': layers.Water,
             'Boundaries': layers.Boundaries,
             'MSA Labels': layers.MSALabels,
-            'County Labels': layers.CountyLabels,
-            'Sequential 3': layers.Sequential3,
-            'Sequential 10': layers.Sequential10,
-            'Plurality': layers.Plurality
+            'County Labels': layers.CountyLabels
         };
 
         // Setup the minimap


### PR DESCRIPTION
- Prevents users from selecting multiple demographic layers accidentally. Can be re-added if multiple layers are desirable at a later time.
