### PR TITLE
Resolved print template name call bug

### DIFF
--- a/mapusaurus/mapping/templates/print_map.html
+++ b/mapusaurus/mapping/templates/print_map.html
@@ -80,7 +80,7 @@
                 <h3>Peer Institutions included in LAR count:</h3>
                 {% for peer in institution_peers %}
                     <span style="display:inline-block; min-width:250px; max-width:250px; height:60px; vertical-align:top;">
-                        <span class="item-main"><b>{{ peer.name }}</b></span><br/><span class="item-sub">{{ peer.institution_id }}</span>
+                        <span class="item-main"><b>{{ peer.institution.name }}</b></span><br/><span class="item-sub">{{ peer.institution_id }}</span>
                     </span>
                 {% endfor %}
             </div>


### PR DESCRIPTION
Was using a deprecated peer.name call.  Fixed.