### PR TITLE
Updates to layer option icon styling and placement

### DIFF
--- a/frontend/src/less/mapusaurus/map.less
+++ b/frontend/src/less/mapusaurus/map.less
@@ -113,8 +113,8 @@ select {
   i.cf-icon-right {
     font-size: .75em;
     position: absolute;
-    right: 30px;
-    top: 12px;
+    right: 10px;
+    top: 13px;
   }
 
   h6 {
@@ -131,6 +131,13 @@ select {
 }
 .map-divider-minor.option.active-layer:hover{
     background: @green-midtone;
+}
+
+#layerOptions .option i {
+  color: @gray-50;
+}
+#layerOptions .option.active-layer i {
+  color: @darkgray;
 }
 
 .header-group {


### PR DESCRIPTION
* Moves icons to be more square to the right of the bars
* Lighter default color for non-selected layers
* Green color for select layer

![screen shot 2015-04-09 at 4 07 38 pm](https://cloud.githubusercontent.com/assets/1689222/7075814/c9a1e8e6-ded2-11e4-89a1-eed527f3249c.png)
