### PR TITLE
Adding logic for extreme odds ratio cases

### DIFF
--- a/mapusaurus/censusdata/tests/test_views_utilities.py
+++ b/mapusaurus/censusdata/tests/test_views_utilities.py
@@ -30,7 +30,7 @@ class ViewsUtilitiesTests(TestCase):
                 self.assertTrue(key in result_dict['msa'].keys())
         self.assertTrue(len(result_dict['msa']) > 0)
         self.assertEqual(result_dict['msa']['lar_total'], 0)
-        self.assertEqual(result_dict['msa']['odds_lma'], 1.0)
+        self.assertIsNone(result_dict['msa']['odds_lma'])
 
     def test_assemble_stats(self):
         """should calculate and return a dict of lender loan totals by minority area"""
@@ -66,6 +66,9 @@ class ViewsUtilitiesTests(TestCase):
         self.assertEqual(odds2, 0.0)
         self.assertEqual(odds3, 0.583)
         self.assertEqual(odds4, 1.0)
+        self.assertIsNone(odds_ratio(1, 0))
+        self.assertIsNone(odds_ratio(0, 0))
+        self.assertEqual(0, odds_ratio(0, 1))
 
 
 

--- a/mapusaurus/censusdata/views.py
+++ b/mapusaurus/censusdata/views.py
@@ -108,7 +108,6 @@ def assemble_stats(lma_sum, mma_sum, hma_sum, peer_lma_sum, peer_mma_sum, peer_h
             'peer_hma_pct': 0,
             'peer_lar_total': 0
         })
-
     odds_lma = odds_ratio(lma_pct, peer_lma_pct)
     odds_mma = odds_ratio(mma_pct, peer_mma_pct)
     odds_hma = odds_ratio(hma_pct, peer_hma_pct)
@@ -128,7 +127,11 @@ def odds_ratio(target_pct, peer_pct):
     is only for mocking data flow to tables
     """
     odds_ratio = 0.0
-    if target_pct == peer_pct:
+    if peer_pct == 0.0:
+        return None
+    elif target_pct == 0.0:
+        odds_ratio = 0.0
+    elif target_pct == peer_pct:
         odds_ratio = 1.0
     elif peer_pct > 0.0 and target_pct < 1.0 and peer_pct < 1.0:
         odds_ratio = (target_pct/(1-target_pct))/(peer_pct/(1-peer_pct))


### PR DESCRIPTION
Adding logic for extreme odds ratio cases: 
peer_pct = 0.0 --> odds = null
target_pct = 0.0 & peer_pct = 0.0 --> odds = null
target_pct = 0.0 --> odds = 0.0
target_pct = peer_pct --> odds = 1.0
