### PR TITLE
Year selection implementation

### DIFF
--- a/frontend/src/js/search.js
+++ b/frontend/src/js/search.js
@@ -1,25 +1,35 @@
 'use strict';
 
 $(document).ready(function() {
-    var search = new Bloodhound({
-        datumTokenizer: function(d) {
-            return Bloodhound.tokenizers.whitespace(d.name);
-        },
-        queryTokenizer: Bloodhound.tokenizers.whitespace,
-        remote: {
-            url: '/institutions/search/?auto=1&q=%QUERY',
-            filter: function(resp) { return resp.institutions;}
-        }
-    }),
-    
-    searchNameBox = $('#search_name');
-    search.initialize();
 
-    searchNameBox.typeahead({
-        highlight: true
-    }, {
-        displayKey: 'formatted_name',
-        source: search.ttAdapter()
+    function initSearch() {
+        var search = new Bloodhound({
+            datumTokenizer: function(d) {
+                return Bloodhound.tokenizers.whitespace(d.name);
+            },
+            queryTokenizer: Bloodhound.tokenizers.whitespace,
+            remote: {
+                url: '/institutions/search/?auto=1&q=%QUERY',
+                filter: function(resp) { return resp.institutions;}
+            }
+        }),
+        
+        searchNameBox = $('#search_name');
+        search.initialize();
+
+        searchNameBox.typeahead({
+            highlight: true
+        }, {
+            displayKey: 'formatted_name',
+            source: search.ttAdapter()
+        });
+    }
+
+    $('#search-year').on('change', function() {
+        var year = $(this).val();
+        $('form.year').addClass('hidden');
+        $('form.year.' + year).removeClass('hidden');
+        initSearch();
     });
 
 });

--- a/frontend/src/js/search.js
+++ b/frontend/src/js/search.js
@@ -2,34 +2,33 @@
 
 $(document).ready(function() {
 
-    function initSearch() {
+    $('form.year').hide();
+
+    $('#search-year').on('change', function() {
+        var year = $(this).val();
+        $('form.year').hide();
+        $('form.year.' + year).show();
+
         var search = new Bloodhound({
+            initialize: false,
             datumTokenizer: function(d) {
                 return Bloodhound.tokenizers.whitespace(d.name);
             },
             queryTokenizer: Bloodhound.tokenizers.whitespace,
             remote: {
-                url: '/institutions/search/?auto=1&q=%QUERY',
+                url: '/institutions/search/?auto=1&year=' + year + '&q=%QUERY',
                 filter: function(resp) { return resp.institutions;}
             }
-        }),
+        });
         
-        searchNameBox = $('#search_name');
         search.initialize();
-
-        searchNameBox.typeahead({
+        
+        $('form.year.' + year + ' .search_institution').typeahead({
             highlight: true
         }, {
             displayKey: 'formatted_name',
             source: search.ttAdapter()
         });
-    }
-
-    $('#search-year').on('change', function() {
-        var year = $(this).val();
-        $('form.year').addClass('hidden');
-        $('form.year.' + year).removeClass('hidden');
-        initSearch();
     });
 
 });

--- a/mapusaurus/respondents/static/respondents/js/search.min.js
+++ b/mapusaurus/respondents/static/respondents/js/search.min.js
@@ -1,30 +1,28 @@
 "use strict";
 
 $(document).ready(function() {
-    function initSearch() {
+    $("form.year").hide(), $("#search-year").on("change", function() {
+        var year = $(this).val();
+        $("form.year").hide(), $("form.year." + year).show();
         var search = new Bloodhound({
+            initialize: !1,
             datumTokenizer: function(d) {
                 return Bloodhound.tokenizers.whitespace(d.name);
             },
             queryTokenizer: Bloodhound.tokenizers.whitespace,
             remote: {
-                url: "/institutions/search/?auto=1&q=%QUERY",
+                url: "/institutions/search/?auto=1&year=" + year + "&q=%QUERY",
                 filter: function(resp) {
                     return resp.institutions;
                 }
             }
-        }), searchNameBox = $("#search_name");
-        search.initialize(), searchNameBox.typeahead({
+        });
+        search.initialize(), $("form.year." + year + " .search_institution").typeahead({
             highlight: !0
         }, {
             displayKey: "formatted_name",
             source: search.ttAdapter()
         });
-    }
-    $("#search-year").on("change", function() {
-        var year = $(this).val();
-        $("form.year").addClass("hidden"), $("form.year." + year).removeClass("hidden"), 
-        initSearch();
     });
 });
 //# sourceMappingURL=search.min.js.map

--- a/mapusaurus/respondents/static/respondents/js/search.min.js
+++ b/mapusaurus/respondents/static/respondents/js/search.min.js
@@ -1,23 +1,30 @@
 "use strict";
 
 $(document).ready(function() {
-    var search = new Bloodhound({
-        datumTokenizer: function(d) {
-            return Bloodhound.tokenizers.whitespace(d.name);
-        },
-        queryTokenizer: Bloodhound.tokenizers.whitespace,
-        remote: {
-            url: "/institutions/search/?auto=1&q=%QUERY",
-            filter: function(resp) {
-                return resp.institutions;
+    function initSearch() {
+        var search = new Bloodhound({
+            datumTokenizer: function(d) {
+                return Bloodhound.tokenizers.whitespace(d.name);
+            },
+            queryTokenizer: Bloodhound.tokenizers.whitespace,
+            remote: {
+                url: "/institutions/search/?auto=1&q=%QUERY",
+                filter: function(resp) {
+                    return resp.institutions;
+                }
             }
-        }
-    }), searchNameBox = $("#search_name");
-    search.initialize(), searchNameBox.typeahead({
-        highlight: !0
-    }, {
-        displayKey: "formatted_name",
-        source: search.ttAdapter()
+        }), searchNameBox = $("#search_name");
+        search.initialize(), searchNameBox.typeahead({
+            highlight: !0
+        }, {
+            displayKey: "formatted_name",
+            source: search.ttAdapter()
+        });
+    }
+    $("#search-year").on("change", function() {
+        var year = $(this).val();
+        $("form.year").addClass("hidden"), $("form.year." + year).removeClass("hidden"), 
+        initSearch();
     });
 });
 //# sourceMappingURL=search.min.js.map

--- a/mapusaurus/respondents/templates/respondents/search_home.html
+++ b/mapusaurus/respondents/templates/respondents/search_home.html
@@ -19,7 +19,7 @@
         <p>Welcome to the Fair Lending HMDA Visualization Toolkit! Please contact us with feedback or questions
         <a class="cf-icon cf-icon-email-social" href="mailto:{{ contact_us_email }}?subject=Visualization%20Toolkit%20Feedback"></a>.</p>
 
-        <p>The tool klasjdflkajsdflkjds loan application records (LAR) from the 2013 HMDA data set for a chosen lender in a selected Metropolitan Statistical Area (MSA). Demographic data displayed is from the 2010 Census (SF-1) and 2013 American Community Survey (ACS).
+        <p>The tool displays loan application records (LAR) from the 2013 HMDA data set for a chosen lender in a selected Metropolitan Statistical Area (MSA). Demographic data displayed is from the 2010 Census (SF-1) and 2013 American Community Survey (ACS).
         <p>&nbsp;</p>
 
         <div class="search-indent">
@@ -28,36 +28,37 @@
                    <div class="circlelabel">1</div>
                 </div>
                 <div class="search-title-column2">
-                    <h3>  Find an institution with 2013 originations</h3>
+                    <h3>  Find an institution with originations in 
+                        <select id="search-year" name="search-year">
+                            <option value=""></option>
+                            <option value="2014">2014</option>
+                            <option value="2013">2013</option>
+                        </select>
+                    </h3>
                 </div>
             </div>
             <p>&nbsp;</p>
-            <p>&nbsp;</p>
+            <p>&nbsp;</p>            
 
-            <label for="search-year" class="search-name-label">Select a year</label>
-            <select id="search-year" name="search-year">
-                <option value=""></option>
-                <option value="2014">2014</option>
-                <option value="2013">2013</option>
-            </select>
-
-            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2013 hidden">
+            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2013">
                 <div class="search-field">
                     <label for="search_name" class="search-name-label">Search by name or lender ID
                         (<a target="new" href="http://www.ffiec.gov/nicpubweb/nicweb/SearchForm.aspx">Need a Lender ID?</a> <span class="cf-icon cf-icon-external-link"></span>)
                     </label>
-                    <input type="text" id="search_name" name="q" />
+                    <input type="text" id="search_name" name="q" class="search_institution" />
+                    <input type="hidden" name="year" value="2013">
                     <button type="submit" class="btn active">Search</button>
                     <span class="example-hint">ex: 99992222111; First Federal Savings</span>
                 </div>
             </form>
 
-            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2014 hidden">
+            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2014">
                 <div class="search-field">
                     <label for="search_name" class="search-name-label">Search by name or lender ID
                         (<a target="new" href="http://www.ffiec.gov/nicpubweb/nicweb/SearchForm.aspx">Need a Lender ID?</a> <span class="cf-icon cf-icon-external-link"></span>)
                     </label>
-                    <input type="text" id="search_name" name="q" />
+                    <input type="text" id="search_name" name="q" class="search_institution" />
+                    <input type="hidden" name="year" value="2014">
                     <button type="submit" class="btn active">Search</button>
                     <span class="example-hint">ex: 99992222111; First Federal Savings</span>
                 </div>

--- a/mapusaurus/respondents/templates/respondents/search_home.html
+++ b/mapusaurus/respondents/templates/respondents/search_home.html
@@ -19,11 +19,11 @@
         <p>Welcome to the Fair Lending HMDA Visualization Toolkit! Please contact us with feedback or questions
         <a class="cf-icon cf-icon-email-social" href="mailto:{{ contact_us_email }}?subject=Visualization%20Toolkit%20Feedback"></a>.</p>
 
-        <p>The tool displays loan application records (LAR) from the 2013 HMDA data set for a chosen lender in a selected Metropolitan Statistical Area (MSA). Demographic data displayed is from the 2010 Census (SF-1) and 2013 American Community Survey (ACS).
+        <p>The tool klasjdflkajsdflkjds loan application records (LAR) from the 2013 HMDA data set for a chosen lender in a selected Metropolitan Statistical Area (MSA). Demographic data displayed is from the 2010 Census (SF-1) and 2013 American Community Survey (ACS).
         <p>&nbsp;</p>
 
         <div class="search-indent">
-            <div >
+            <div>
                 <div class="search-title-column1">
                    <div class="circlelabel">1</div>
                 </div>
@@ -34,8 +34,14 @@
             <p>&nbsp;</p>
             <p>&nbsp;</p>
 
+            <label for="search-year" class="search-name-label">Select a year</label>
+            <select id="search-year" name="search-year">
+                <option value=""></option>
+                <option value="2014">2014</option>
+                <option value="2013">2013</option>
+            </select>
 
-            <form action="{% url 'respondents:search_results' %}" method="GET">
+            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2013 hidden">
                 <div class="search-field">
                     <label for="search_name" class="search-name-label">Search by name or lender ID
                         (<a target="new" href="http://www.ffiec.gov/nicpubweb/nicweb/SearchForm.aspx">Need a Lender ID?</a> <span class="cf-icon cf-icon-external-link"></span>)
@@ -45,6 +51,18 @@
                     <span class="example-hint">ex: 99992222111; First Federal Savings</span>
                 </div>
             </form>
+
+            <form action="{% url 'respondents:search_results' %}" method="GET" class="year 2014 hidden">
+                <div class="search-field">
+                    <label for="search_name" class="search-name-label">Search by name or lender ID
+                        (<a target="new" href="http://www.ffiec.gov/nicpubweb/nicweb/SearchForm.aspx">Need a Lender ID?</a> <span class="cf-icon cf-icon-external-link"></span>)
+                    </label>
+                    <input type="text" id="search_name" name="q" />
+                    <button type="submit" class="btn active">Search</button>
+                    <span class="example-hint">ex: 99992222111; First Federal Savings</span>
+                </div>
+            </form>
+
         </div>
         
     </div>


### PR DESCRIPTION
@sleitner Here's a prototype of how the year selection will work. It's incredibly hacky at the moment but it demonstrates how we can handle the search endpoints.

On the institutions search page, instead of the typeahead requesting:
```
http://localhost:8081/institutions/search/?auto=1&q=wells
```
It now requests:
```
http://localhost:8081/institutions/search/?auto=1&year=2014&q=wells
```

Or 2013 if you selected that in the dropdown at http://localhost:8081/institutions/. We can discuss on Monday.