### PR TITLE
Adding 2016 year map layer

### DIFF
--- a/mapusaurus/mapping/templates/map.html
+++ b/mapusaurus/mapping/templates/map.html
@@ -164,6 +164,28 @@
             Branches: L.layerGroup([])
         };
 
+        yearLayers['2016'] = {
+            MBBase: L.tileLayer('https://{s}.tiles.mapbox.com/v4/cfpb.k55b27gd/{z}/{x}/{y}.png?access_token=' + L.mapbox.accessToken),
+            Base: L.mapbox.tileLayer('cfpb.a760eab8', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            Water: L.mapbox.tileLayer('cfpb.FL_WATER_all_US', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            Boundaries: L.mapbox.tileLayer('cfpb.4a612b0a', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            CountyLabels: L.mapbox.tileLayer('cfpb.5cc6733d', {errorTileUrl: '/static/basestyle/img/0.png'}),            
+            MSALabels: L.mapbox.tileLayer('cfpb.434952df', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            PctMinority: L.mapbox.tileLayer('cfpb.8961f4ed', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            // The following two layers were created with MapBox Studio. Eventually, all layers will use this new format.
+            PctHispanic: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikiwpxi500639akpqyjis3jl/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            PctBlack: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikiy27e5006hbgm1b1k429kn/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            PctAsian: L.mapbox.tileLayer('cfpb.20020fca', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            PctWhite: L.mapbox.tileLayer('cfpb.bdb5ee3b', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            Plurality: L.mapbox.tileLayer('cfpb.FL_TRACT_minor_plurality_US', {errorTileUrl: '/static/basestyle/img/0.png'}),
+            MedianIncome: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikpm3d7c00ks96kq8kmagjb7/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            OwnerOccupancy: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikpmq2a800k89vm0t6jhcl5s/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            MedianValue: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikpm2exq00m3bgm1ee851343/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            MedianYearBuilt: L.tileLayer('https://api.mapbox.com/styles/v1/cfpb/cikpmaa7z00m4bgm19yf8vsj5/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {errorTileUrl: '/static/basestyle/img/0.png'}),
+            Centroids: L.layerGroup([]),
+            Branches: L.layerGroup([])
+        };        
+
         // Reference the layers that correspond to the selected year.
         var layers = yearLayers[selectedYear];
 


### PR DESCRIPTION
Mapping layer duplicates existing layer styles for now, but allows layers to be displayed for any 2016 data that is requested until such time when 2016 layers are sufficiently updated.